### PR TITLE
Nested attributes and validators

### DIFF
--- a/lib/lotus/validations.rb
+++ b/lib/lotus/validations.rb
@@ -198,10 +198,14 @@ module Lotus
     #
     # @since 0.1.0
     def valid?
-      validator = Validator.new(defined_validations, read_attributes)
-      @errors = validator.validate
+      validate
 
       errors.empty?
+    end
+
+    def validate
+      validator = Validator.new(defined_validations, read_attributes)
+      @errors = validator.validate
     end
 
     # Iterates thru the defined attributes and their values

--- a/lib/lotus/validations.rb
+++ b/lib/lotus/validations.rb
@@ -204,8 +204,8 @@ module Lotus
     end
 
     def validate
-      validator = Validator.new(defined_validations, read_attributes)
-      @errors = validator.validate
+      validator = Validator.new(defined_validations, read_attributes, errors)
+      validator.validate
     end
 
     # Iterates thru the defined attributes and their values

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -45,7 +45,18 @@ module Lotus
       # @api private
       # @since 0.2.0
       def validate
-        _run_validations
+        presence
+        acceptance
+
+        return if skip?
+
+        format
+        inclusion
+        exclusion
+        size
+        confirmation
+        nested
+
         @errors
       end
 
@@ -206,24 +217,6 @@ module Lotus
       # @api private
       def blank_value?
         BlankValueChecker.new(@value).blank_value?
-      end
-
-      # Run the defined validations
-      #
-      # @since 0.2.0
-      # @api private
-      def _run_validations
-        presence
-        acceptance
-
-        return if skip?
-
-        format
-        inclusion
-        exclusion
-        size
-        confirmation
-        nested
       end
 
       # Reads an attribute from the validator.

--- a/lib/lotus/validations/attribute.rb
+++ b/lib/lotus/validations/attribute.rb
@@ -34,20 +34,19 @@ module Lotus
       #
       # @since 0.2.0
       # @api private
-      def initialize(attributes, name, value, validations)
+      def initialize(attributes, name, value, validations, errors)
         @attributes  = attributes
         @name        = name
         @value       = value
         @validations = validations
-        @errors      = []
+        @errors      = errors
       end
 
       # @api private
       # @since 0.2.0
       def validate
-        _with_cleared_errors do
-          _run_validations
-        end
+        _run_validations
+        @errors
       end
 
       # @api private
@@ -183,6 +182,16 @@ module Lotus
         end
       end
 
+      # Validates nested Lotus Validations objects
+      #
+      # @since x.x.x
+      # @api private
+      def nested
+        _validate(__method__) do |validator|
+          @errors.set @name, value.validate
+        end
+      end
+
       # @since 0.1.0
       # @api private
       def skip?
@@ -214,14 +223,7 @@ module Lotus
         exclusion
         size
         confirmation
-      end
-
-      # @api private
-      # @since 0.2.0
-      def _with_cleared_errors
-        @errors.clear
-        yield
-        @errors.dup.tap {|_| @errors.clear }
+        nested
       end
 
       # Reads an attribute from the validator.
@@ -238,7 +240,7 @@ module Lotus
       # @api private
       def _validate(validation)
         if (validator = @validations[validation]) && !(yield validator)
-          @errors.push(Error.new(@name, validation, @validations.fetch(validation), @value))
+          @errors.add(@name, Error.new(@name, validation, @validations.fetch(validation), @value))
         end
       end
     end

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -270,6 +270,7 @@ module Lotus
           define_lazy_reader(name, nested_class)
           define_coerced_writer(name, nested_class)
           defined_attributes.add(name.to_s)
+          validates(name, nested: true)
         end
 
         # @since 0.2.2

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -235,10 +235,7 @@ module Lotus
 
         def attribute(name, options = {}, &block)
           if block_given?
-            nested_class = build_validation_class(&block)
-            define_lazy_reader(name, nested_class)
-            define_coerced_writer(name, nested_class)
-            defined_attributes.add(name.to_s)
+            define_nested_attribute(name, options, &block)
             validates(name, {})
           else
             define_attribute(name, options)
@@ -264,6 +261,15 @@ module Lotus
             define_accessor(confirmation_accessor, type)
             defined_attributes.add(confirmation_accessor)
           end
+        end
+
+        # @since x.x.x
+        # @api private
+        def define_nested_attribute(name, options, &block)
+          nested_class = build_validation_class(&block)
+          define_lazy_reader(name, nested_class)
+          define_coerced_writer(name, nested_class)
+          defined_attributes.add(name.to_s)
         end
 
         # @since 0.2.2

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -236,7 +236,8 @@ module Lotus
         def attribute(name, options = {}, &block)
           if block_given?
             nested_class = build_validation_class(&block)
-            define_attribute(name, options.merge(type: nested_class))
+            define_lazy_reader(name, nested_class)
+            define_coerced_writer(name, nested_class)
           else
             define_attribute(name, options)
             validates(name, options)
@@ -296,6 +297,12 @@ module Lotus
         def define_reader(name)
           define_method(name) do
             @attributes.get(name)
+          end
+        end
+
+        def define_lazy_reader(name, type)
+          define_method(name) do
+            @attributes.get(name) || @attributes.set(name, type.new({}))
           end
         end
 

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -301,9 +301,18 @@ module Lotus
           end
         end
 
+        # Defines a reader that will return a new instance of
+        # the given type if one is not already present
+        #
+        # @since x.x.x
+        # @api private
         def define_lazy_reader(name, type)
           define_method(name) do
-            @attributes.get(name) || @attributes.set(name, type.new({}))
+            value = @attributes.get(name)
+            return value if value
+            type.new({}).tap do |value|
+              @attributes.set(name, value)
+            end
           end
         end
 

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -238,6 +238,7 @@ module Lotus
             nested_class = build_validation_class(&block)
             define_lazy_reader(name, nested_class)
             define_coerced_writer(name, nested_class)
+            defined_attributes.add(name.to_s)
             validates(name, {})
           else
             define_attribute(name, options)

--- a/lib/lotus/validations/attribute_definer.rb
+++ b/lib/lotus/validations/attribute_definer.rb
@@ -238,6 +238,7 @@ module Lotus
             nested_class = build_validation_class(&block)
             define_lazy_reader(name, nested_class)
             define_coerced_writer(name, nested_class)
+            validates(name, {})
           else
             define_attribute(name, options)
             validates(name, options)

--- a/lib/lotus/validations/errors.rb
+++ b/lib/lotus/validations/errors.rb
@@ -97,6 +97,10 @@ module Lotus
         @errors[attribute].push(*errors) if errors.any?
       end
 
+      def add_nested(attribute, errors)
+        @errors[attribute] = errors
+      end
+
       # Return the errors for the given attribute
       #
       # @param attribute [Symbol] the name of the attribute

--- a/lib/lotus/validations/errors.rb
+++ b/lib/lotus/validations/errors.rb
@@ -97,7 +97,11 @@ module Lotus
         @errors[attribute].push(*errors) if errors.any?
       end
 
-      def add_nested(attribute, errors)
+      # Sets the errors for an attribute to a given object
+      #
+      # @since x.x.x
+      # @api private
+      def set(attribute, errors)
         @errors[attribute] = errors
       end
 

--- a/lib/lotus/validations/validation_set.rb
+++ b/lib/lotus/validations/validation_set.rb
@@ -16,7 +16,8 @@ module Lotus
         :inclusion,
         :exclusion,
         :confirmation,
-        :size
+        :size,
+        :nested
       ].freeze
 
       # @since 0.2.2

--- a/lib/lotus/validations/validator.rb
+++ b/lib/lotus/validations/validator.rb
@@ -5,23 +5,24 @@ module Lotus
     # @since 0.2.2
     # @api private
     class Validator
-      def initialize(validation_set, attributes)
+      def initialize(validation_set, attributes, errors)
         @validation_set = validation_set
         @attributes = attributes
+        @errors = errors
       end
 
       # @since 0.2.2
       # @api private
       def validate
-        Errors.new.tap do |errors|
-          @validation_set.each do |name, validations|
-            value = @attributes[name]
-            value = @attributes[name.to_s] if value.nil?
+        @errors.clear
+        @validation_set.each do |name, validations|
+          value = @attributes[name]
+          value = @attributes[name.to_s] if value.nil?
 
-            attribute = Attribute.new(@attributes, name, value, validations, errors)
-            attribute.validate
-          end
+          attribute = Attribute.new(@attributes, name, value, validations, @errors)
+          attribute.validate
         end
+        @errors
       end
     end
   end

--- a/lib/lotus/validations/validator.rb
+++ b/lib/lotus/validations/validator.rb
@@ -18,12 +18,8 @@ module Lotus
             value = @attributes[name]
             value = @attributes[name.to_s] if value.nil?
 
-            if value.respond_to?(:validate)
-              errors.set name, value.validate
-            else
-              attribute = Attribute.new(@attributes, name, value, validations)
-              errors.add name, *attribute.validate
-            end
+            attribute = Attribute.new(@attributes, name, value, validations, errors)
+            attribute.validate
           end
         end
       end

--- a/lib/lotus/validations/validator.rb
+++ b/lib/lotus/validations/validator.rb
@@ -18,8 +18,12 @@ module Lotus
             value = @attributes[name]
             value = @attributes[name.to_s] if value.nil?
 
-            attribute = Attribute.new(@attributes, name, value, validations)
-            errors.add name, *attribute.validate
+            if value.respond_to?(:validate)
+              errors.add_nested name, value.validate
+            else
+              attribute = Attribute.new(@attributes, name, value, validations)
+              errors.add name, *attribute.validate
+            end
           end
         end
       end

--- a/lib/lotus/validations/validator.rb
+++ b/lib/lotus/validations/validator.rb
@@ -19,7 +19,7 @@ module Lotus
             value = @attributes[name.to_s] if value.nil?
 
             if value.respond_to?(:validate)
-              errors.add_nested name, value.validate
+              errors.set name, value.validate
             else
               attribute = Attribute.new(@attributes, name, value, validations)
               errors.add name, *attribute.validate

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -21,5 +21,9 @@ describe Lotus::Validations do
       validator.address.line_one.must_equal('10 High Street')
       validator.name.must_equal('John Smith')
     end
+
+    it 'responds with an empty class on nil' do
+      @klass.new({}).address.line_one.must_be_nil
+    end
   end
 end

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+describe Lotus::Validations do
+  describe 'nested attributes' do
+    before do
+      @klass = Class.new do
+        include Lotus::Validations
+
+        attribute :name, type: String
+        attribute :address do
+          attribute :line_one, type: String, presence: true
+          attribute :city, type: String
+          attribute :country, type: String
+          attribute :post_code, type: String
+        end
+      end
+    end
+
+    it 'builds nested attributes' do
+      validator = @klass.new(name: 'John Smith', address: { line_one: '10 High Street' })
+      validator.address.line_one.must_equal('10 High Street')
+      validator.name.must_equal('John Smith')
+    end
+  end
+end

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -25,5 +25,12 @@ describe Lotus::Validations do
     it 'responds with an empty class on nil' do
       @klass.new({}).address.line_one.must_be_nil
     end
+
+    it 'validates nested attributes' do
+      validator = @klass.new(name: 'John Smith', address: { city: 'Melbourne' })
+      validator.valid?.must_equal(false)
+      line_one_error = validator.errors.for(:address).for(:line_one)
+      line_one_error.must_include(Lotus::Validations::Error.new(:line_one, :presence, true, nil))
+    end
   end
 end


### PR DESCRIPTION
This PR implements [nested attributes](https://github.com/lotus/validations/issues/35) and validations by building an anonymous class with lotus validations included for the nested attribute. This works because when the nested hash is assigned, the coercer instantiates the anonymous type with the hash, building a nested validator with all it's attributes.

To make the top level `params.valid?` take into account nested validators, there's a new validation in `Attribute` which uses a new `errors.set` method to assign the returned `Errors` object to the attribute. This means you can query for errors like this `validator.errors.for(:address).for(:line_one)`. Is this the interface we want for nested validation errors?
